### PR TITLE
Support maven custom property for versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A semantic-release plugin to update version for multi-lingual mono repository st
 ## Install
 
 ```bash
-$ npm install https://github.com/SoftwareAG/semantic-release-monorepo/releases/download/v1.0.3/semantic-release-monorepo-1.0.3.tgz  -D
+$ npm install https://github.com/SoftwareAG/semantic-release-monorepo/releases/download/v1.2.0/semantic-release-monorepo-1.2.0.tgz  -D
 ```
 
 ## Usage
@@ -99,7 +99,7 @@ The `pluginConfig` when semantic release is run from `webapp` project
 **Important** : If the main project is maven, ensure to install semantic-release and other plugins globally.
 
 ```bash
-$ npm install -g semantic-release https://github.com/SoftwareAG/semantic-release-monorepo/releases/download/v1.0.3/semantic-release-monorepo-1.0.3.tgz
+$ npm install -g semantic-release https://github.com/SoftwareAG/semantic-release-monorepo/releases/download/v1.2.0/semantic-release-monorepo-1.2.0.tgz
 ```
 
 For the project structure as below, add the semantic-release configuration file and run semantic-release from the project root folder
@@ -128,6 +128,34 @@ the `pluginConfiguration` in release.config.js is
             "type": "maven"
         }
     ]
+}
+```
+
+For projects that use CI-friendly versions (where the version in pom.xml is like ${revision}), to update the property rather than the version directly, use the configuration
+
+```json
+{
+  "type": "maven",
+  "versioningOptions": {
+    "customVersionProperty": "revision"
+  }
+}
+```
+
+For monorepo configuration where dependencies are specified, use the configuration as
+
+```json
+{
+  "type": "maven",
+  "dependencies": [
+    {
+      "type": "maven",
+      "pkgRoot": "..",
+      "versioningOptions": {
+        "customVersionProperty": "revision"
+      }
+    }
+  ]
 }
 ```
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -14,16 +14,20 @@ import { getResolvedPath } from './util.js';
  * @param {WritableStream} context.stderr - The standard error stream.
  */
 export default async function (
-  { type, dependencies = [] },
+  { type, dependencies = [], versioningOptions },
   { nextRelease: { version }, logger, cwd, env, stdout, stderr }
 ) {
   //if type at project level is specified, use that
-  await updateVersion(version, { cwd, logger, stdout, stderr, env }, { type });
+  await updateVersion(version, { cwd, logger, stdout, stderr, env }, { type, versioningOptions });
   for (let dependency of dependencies) {
     await updateVersion(
       version,
       { cwd, logger, stdout, stderr, env },
-      { type: dependency.type, pkgRoot: dependency.pkgRoot }
+      {
+        type: dependency.type,
+        pkgRoot: dependency.pkgRoot,
+        versioningOptions: dependency.versioningOptions
+      }
     );
   }
 }
@@ -38,13 +42,16 @@ export default async function (
  * @param {WritableStream} options.stderr - The standard error stream.
  * @param {string} [options.type='yarn'] - The package manager to use.
  * @param {string} [options.pkgRoot=options.cwd] - The root directory of the package.
+ * @
  */
 async function updateVersion(
   version,
   { cwd, logger, stdout, stderr, env },
-  { type = 'yarn', pkgRoot = cwd }
+  { type = 'yarn', pkgRoot = cwd, versioningOptions }
 ) {
-  logger.log(`updateVersion(${version}, ${cwd}, ${type}, ${pkgRoot})`);
+  logger.log(
+    `updateVersion(${version}, ${cwd}, ${type}, ${pkgRoot}, ${JSON.stringify(versioningOptions)})`
+  );
   const resolvedPath = getResolvedPath(pkgRoot, cwd);
   switch (type) {
     case 'yarn':
@@ -57,7 +64,12 @@ async function updateVersion(
       await updateVersionWithNpm(version, resolvedPath, { logger, stdout, stderr });
       break;
     case 'maven':
-      await updateVersionWithMaven(version, resolvedPath, { logger, stdout, stderr, env });
+      await updateVersionWithMaven(
+        version,
+        resolvedPath,
+        { logger, stdout, stderr, env },
+        versioningOptions
+      );
       break;
   }
 }
@@ -92,12 +104,8 @@ async function updateVersionWithYarn(version, basePath, { logger, stdout, stderr
  * @param {WritableStream} options.stdout - The standard output stream.
  * @param {WritableStream} options.stderr - The standard error stream.
  */
-async function updateVersionWithYarnBerry(version, basePath, { logger, stdout, stderr }){
-  const command = execa(
-    'yarn',
-    ['version', version ],
-    { cwd: basePath, preferLocal: true }
-  )
+async function updateVersionWithYarnBerry(version, basePath, { logger, stdout, stderr }) {
+  const command = execa('yarn', ['version', version], { cwd: basePath, preferLocal: true });
   command.stdout.pipe(stdout, { end: false });
   command.stderr.pipe(stderr, { end: false });
   await command;
@@ -134,13 +142,39 @@ async function updateVersionWithNpm(version, basePath, { logger, stdout, stderr 
  * @param {WritableStream} options.stderr - The standard error stream.
  * @param {Object} options.env - The environment variables.
  */
-async function updateVersionWithMaven(version, basePath, { logger, stdout, stderr, env }) {
+async function updateVersionWithMaven(
+  version,
+  basePath,
+  { logger, stdout, stderr, env },
+  versioningOptions
+) {
   logger.log(`Updating version to ${version} with maven at ${basePath}`);
-  const command = execa('mvn', ['versions:set', `-DnewVersion=${version}`], {
+  const defaultCommand = execa('mvn', ['versions:set', `-DnewVersion=${version}`], {
     cwd: basePath,
     env,
     preferLocal: true
   });
+  let command;
+  if (versioningOptions) {
+    if (versioningOptions.customVersionProperty) {
+      command = execa(
+        'mvn',
+        [
+          'versions:set-property',
+          `-Dproperty=${versioningOptions.customVersionProperty}`,
+          `-DnewVersion=${version}`
+        ],
+        {
+          cwd: basePath,
+          env,
+          preferLocal: true
+        }
+      );
+    }
+  } else {
+    command = defaultCommand;
+  }
+
   command.stdout.pipe(stdout, { end: false });
   command.stderr.pipe(stderr, { end: false });
   await command;

--- a/test/fixtures/prepare-test-05/pom.xml
+++ b/test/fixtures/prepare-test-05/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <groupId>com.example</groupId>
+    <artifactId>my-project</artifactId>
+    <version>${revision}</version>
+    
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <revision>1.0.0</revision>
+    </properties>
+    
+    <dependencies>
+        <!-- Add your dependencies here -->
+    </dependencies>
+    
+    <build>
+        <plugins>
+            <!-- Add your build plugins here -->
+        </plugins>
+    </build>
+</project>

--- a/test/helpers/util.js
+++ b/test/helpers/util.js
@@ -24,3 +24,13 @@ export const getVersion = async (type, filePath) => {
   }
   return version;
 };
+
+export const getMavenPropertyValue = async (filePath, propertyName) => {
+  const fileContent = await fsPromises.readFile(filePath, 'utf8');
+  const parser = new XMLParser();
+  const pomJson = parser.parse(fileContent);
+  const properties = pomJson.project.properties;
+  if (properties && properties[propertyName]) {
+    return properties[propertyName];
+  }
+};


### PR DESCRIPTION
DTM microservice switched from using version to revision property in the pom.xml to hold version. The current PR provides configuration option to use a custom property in pom.xml