### PR TITLE
Place the versions subcommand in the args list

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -151,8 +151,12 @@ async function updateCustomVersionProperty(
   versioningOptions
 ) {
   logger.log(`Updating version to ${version} with maven at ${basePath}`);
-  const commandstr = 'mvn versions:set-property';
-  const args = [`-Dproperty=${versioningOptions.customVersionProperty}`, `-DnewVersion=${version}`];
+  const commandstr = 'mvn';
+  const args = [
+    'versions:set-property',
+    `-Dproperty=${versioningOptions.customVersionProperty}`,
+    `-DnewVersion=${version}`
+  ];
   const options = { cwd: basePath, preferLocal: true, env };
 
   const command = execa(commandstr, args, options);


### PR DESCRIPTION
When updating custom version field using maven versions:set-property command, versions:set-property sub command was passed in the command parameter instead of args which failed when run on ci environment. this change resolves the problem